### PR TITLE
If user cancel don't display error message

### DIFF
--- a/src/components/modals/settings/SettingsModal.vue
+++ b/src/components/modals/settings/SettingsModal.vue
@@ -98,6 +98,10 @@
               vm.$Message.success(this.$t('modals.file_saved_success'));
             })
             .catch((err) => {
+              if(fileName == ''){
+                return;
+              }
+              
               vm.$Message.error({content: err.message, duration: 0, closable: true});
             });
         });


### PR DESCRIPTION
If a user cancels when creating the backup file don't display the error message.
The filename will be empty if the user cancels the operation.